### PR TITLE
updated sponsors (organized and tiered)

### DIFF
--- a/src/components/SponsorsDisplay.vue
+++ b/src/components/SponsorsDisplay.vue
@@ -5,16 +5,16 @@ import WOLF from "@/assets/images/sponsors/wolfram.png";
 import DESHAW from "@/assets/images/sponsors/deshaw.png";
 import MLH from "@/assets/images/sponsors/mlh-logo.svg";
 import YALE from "@/assets/images/sponsors/yale.png";
-import FETCH from "@/assets/images/sponsors/fetchai.png"
+import FETCH from "@/assets/images/sponsors/fetchai.png";
 
 const sponsors = [
+  { name: "FETCH", src: FETCH, url: "https://fetch.ai/" },
   { name: "D.E. Shaw", src: DESHAW, url: "https://www.deshaw.com/" },
   { name: "Wolfram", src: WOLF, url: "https://www.wolfram.com/" },
-  { name: "SEAS", src: SEAS, url: "https://seas.yale.edu/" },
-  { name: "TSAI CITY", src: TSAI, url: "https://city.yale.edu/" },
-  { name: "FETCH", src: FETCH, url: "https://fetch.ai/"},
-  { name: "YALE", src: YALE, url: "https://yalecollege.yale.edu/" },
   { name: "MLH", src: MLH, url: "https://mlh.io/" },
+  { name: "TSAI CITY", src: TSAI, url: "https://city.yale.edu/" },
+  { name: "YALE", src: YALE, url: "https://yalecollege.yale.edu/" },
+  { name: "SEAS", src: SEAS, url: "https://seas.yale.edu/" },
 ];
 </script>
 
@@ -39,10 +39,56 @@ const sponsors = [
       >!
     </h3>
     <div class="sponsorsdisplay">
+      <!-- fetch.ai -->
       <div class="sponsorsinfo">
         <a
           class="sponsorslink"
-          v-for="(sponsor, index) in sponsors"
+          :href="sponsors[0].url"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            :src="sponsors[0].src"
+            :alt="sponsors[0].name"
+            class="sponsorslogo-large"
+          />
+        </a>
+      </div>
+      <!-- D.E. Shaw -->
+      <div class="sponsorsinfo">
+        <a
+          class="sponsorslink"
+          :href="sponsors[1].url"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            :src="sponsors[1].src"
+            :alt="sponsors[1].name"
+            class="sponsorslogo-medium"
+          />
+        </a>
+      </div>
+      <!-- Wolfram -->
+      <div class="sponsorsinfo">
+        <a
+          class="sponsorslink"
+          :href="sponsors[2].url"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            :src="sponsors[2].src"
+            :alt="sponsors[2].name"
+            class="sponsorslogo"
+          />
+        </a>
+      </div>
+      <!-- Remaining Sponsors -->
+      <div class="sponsorsinfo remaining-sponsors">
+        <a
+          class="sponsorslink"
+          v-for="(sponsor, index) in sponsors.slice(3)"
           :key="index"
           :href="sponsor.url"
           target="_blank"
@@ -60,39 +106,48 @@ const sponsors = [
 .sponsors {
   padding: 3rem 0;
 }
+
 .head {
   font-size: 3.25rem;
   text-shadow: -3px 3px #cd21fd;
 }
+
 .certif {
   font-size: 2.625rem !important;
   margin-right: 0.25rem;
 }
+
 .sponsormsg {
   font-size: 2rem;
   padding: 1.5rem 0 0.5rem 0;
 }
+
 .sponsormsg span {
   font-style: italic;
   font-weight: 400;
 }
+
 .dropemail {
   font-size: 1.5rem;
   font-weight: 300;
 }
+
 @media screen and (min-width: 768px) {
   .dropemail {
     font-size: 2rem;
   }
 }
+
 .dropemail a {
   color: #fff;
   text-decoration: underline;
 }
+
 .sponsorsdisplay {
   margin-top: 1.75rem;
   border-left: 0.75rem solid #fff;
 }
+
 .sponsorsinfo {
   display: flex;
   flex-wrap: wrap;
@@ -106,26 +161,56 @@ const sponsors = [
     rgba(255, 255, 255, 0.875)
   );
 }
+
+/* for fetch.ai */
+.sponsorslogo-large {
+  width: 500px;
+  padding: 1rem;
+  transition: 250ms;
+}
+
+/* for D.E. Shaw */
+.sponsorslogo-medium {
+  width: 400px;
+  padding: 1rem;
+  transition: 250ms;
+}
+
 .sponsorslogo {
   max-width: 250px;
   width: 100%;
   padding: 1rem;
   transition: 250ms;
 }
+
 .moresponsors {
   padding: 1rem 0;
   font-size: 1.5rem;
 }
+
 @media only screen and (max-width: 767px) {
   .sponsorsinfo {
     margin-left: 1rem;
   }
 }
+
 @media (hover: hover) {
   .sponsorslogo:hover {
     transform: scale(1.075);
   }
   .sponsorslogo:active {
+    transform: scale(0.975);
+  }
+  .sponsorslogo-large:hover {
+    transform: scale(1.075);
+  }
+  .sponsorslogo-large:active {
+    transform: scale(0.975);
+  }
+  .sponsorslogo-medium:hover {
+    transform: scale(1.075);
+  }
+  .sponsorslogo-medium:active {
     transform: scale(0.975);
   }
 }


### PR DESCRIPTION
separated sponsor logos into fetch.ai at the top, then de shaw, then wolfram, and then everything else. added css for fetch.ai and de shaw logos (.sponsorslogo-large and .sponsorslogo-medium respectively). updated hover transition accordingly